### PR TITLE
fix: no Optional for default value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
* If the particle is an element declaration, do not generate an Optional if there's a default value.
* Support for Jakarta JAXB element. Note that the existing XJC API seems backwards compatible with current and as such the plugin still works with Jakarta XML Binding.
* Bump compiler source / target to Java 8.

Fixes #3